### PR TITLE
perf: PDFプレビューをHTML/CSSベースに置き換え、大幅に高速化

### DIFF
--- a/e2e/download-platform.spec.ts
+++ b/e2e/download-platform.spec.ts
@@ -1,0 +1,243 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const pdfParse = require('pdf-parse') as (buffer: Buffer) => Promise<{ text: string }>;
+
+/**
+ * フォームに最低限のデータを入力するヘルパー
+ */
+async function fillMinimalForm(page: import('@playwright/test').Page) {
+  await page.locator('#subject').fill('ダウンロードテスト');
+  await page.locator('#item-0-description').fill('テスト品目');
+  await page.locator('#item-0-quantity').fill('1');
+  await page.locator('#item-0-unitPrice').fill('1000');
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+});
+
+// ---------------------------------------------------------------------------
+// PC（Desktop Chrome）: download 属性付き <a> 経由でダウンロードされる
+// ---------------------------------------------------------------------------
+test.describe('PC: ダウンロード動作', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test('window.open が呼ばれず download イベントで PDF を取得できる', async ({ page, context }) => {
+    await fillMinimalForm(page);
+
+    // window.open の呼び出しを記録
+    await page.evaluate(() => {
+      (window as any).__openCalls = [];
+      const orig = window.open;
+      window.open = function (...args: any[]) {
+        (window as any).__openCalls.push(args);
+        return orig.apply(this, args);
+      };
+    });
+
+    const downloadButton = page.getByRole('button', { name: 'PDFをダウンロード' });
+    await downloadButton.scrollIntoViewIfNeeded();
+
+    // popup が開かないことも確認
+    let popupOpened = false;
+    context.on('page', () => { popupOpened = true; });
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download', { timeout: 60000 }),
+      downloadButton.click(),
+    ]);
+
+    // download イベントでファイルを取得
+    expect(download.suggestedFilename()).toMatch(/^invoice-.*\.pdf$/);
+
+    // 実際に有効な PDF であることを確認
+    const filePath = await download.path();
+    expect(filePath).toBeTruthy();
+    const buffer = fs.readFileSync(filePath!);
+    const pdf = await pdfParse(buffer);
+    expect(pdf.text).toContain('テスト品目');
+
+    // window.open は呼ばれていないこと
+    const openCalls = await page.evaluate(() => (window as any).__openCalls);
+    expect(openCalls).toHaveLength(0);
+    expect(popupOpened).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// iOS Safari エミュレーション: window.open で新タブにPDFが表示される
+// ---------------------------------------------------------------------------
+test.describe('iOS: ダウンロード動作', () => {
+  test.use({
+    viewport: { width: 390, height: 844 },
+    userAgent:
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+  });
+
+  test('window.open が呼ばれ blob URL が渡される', async ({ page, context }) => {
+    await fillMinimalForm(page);
+
+    // window.open をラップして blob URL の受け渡しをキャプチャ
+    // Chromium では blob URL への location.href 代入がダウンロードをトリガーし
+    // popup.url() が更新されないため、ラッパー経由で検証する
+    await page.evaluate(() => {
+      (window as any).__iOSDownload = { windowOpened: false, blobUrl: null };
+      const origOpen = window.open.bind(window);
+      window.open = function (...args: any[]) {
+        (window as any).__iOSDownload.windowOpened = true;
+        const realWin = origOpen(...args);
+        if (!realWin) return realWin;
+        // location.href 代入をキャプチャするラッパーを返す
+        return {
+          get location() {
+            return {
+              get href() { return realWin.location.href; },
+              set href(val: string) {
+                (window as any).__iOSDownload.blobUrl = val;
+                realWin.location.href = val;
+              },
+            };
+          },
+          set location(val: any) {
+            (window as any).__iOSDownload.blobUrl = typeof val === 'string' ? val : val?.href;
+            realWin.location = val;
+          },
+          close() { realWin.close(); },
+        };
+      };
+    });
+
+    const downloadButton = page.getByRole('button', { name: 'PDFをダウンロード' });
+    await downloadButton.scrollIntoViewIfNeeded();
+
+    // popup を待ち受けてクリック
+    const [popup] = await Promise.all([
+      context.waitForEvent('page', { timeout: 60000 }),
+      downloadButton.click(),
+    ]);
+
+    // 新しいタブが開かれたこと
+    expect(popup).toBeTruthy();
+
+    // PDF 生成が完了するまで待機（ボタンが元に戻る）
+    await expect(page.getByRole('button', { name: 'PDFをダウンロード' }))
+      .toBeEnabled({ timeout: 60000 });
+
+    // window.open が呼ばれ、blob URL が渡されたことを確認
+    const data = await page.evaluate(() => (window as any).__iOSDownload);
+    expect(data.windowOpened).toBe(true);
+    expect(data.blobUrl).toMatch(/^blob:/);
+  });
+
+  test('非 iOS 環境では window.open が呼ばれない（UA 判定の検証）', async ({ page }) => {
+    // このテストは iOS UA が設定されているスコープ内だが、
+    // navigator.userAgent を上書きして非 iOS をシミュレート
+    await page.evaluate(() => {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+        configurable: true,
+      });
+    });
+    await fillMinimalForm(page);
+
+    await page.evaluate(() => {
+      (window as any).__openCalls = [];
+      const orig = window.open.bind(window);
+      window.open = function (...args: any[]) {
+        (window as any).__openCalls.push(args);
+        return orig.apply(this, args);
+      };
+    });
+
+    const downloadButton = page.getByRole('button', { name: 'PDFをダウンロード' });
+    await downloadButton.scrollIntoViewIfNeeded();
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download', { timeout: 60000 }),
+      downloadButton.click(),
+    ]);
+
+    expect(download.suggestedFilename()).toMatch(/^invoice-.*\.pdf$/);
+
+    // window.open は呼ばれていないこと
+    const openCalls = await page.evaluate(() => (window as any).__openCalls);
+    expect(openCalls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ボタン状態: ダウンロード中の UI フィードバック
+// ---------------------------------------------------------------------------
+test.describe('ダウンロードボタンの状態管理', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test('ダウンロード中にボタンテキストが「準備中...」に変わり disabled になる', async ({ page }) => {
+    await fillMinimalForm(page);
+
+    const downloadButton = page.getByRole('button', { name: 'PDFをダウンロード' });
+    await downloadButton.scrollIntoViewIfNeeded();
+
+    // クリック前: 有効で「PDFをダウンロード」
+    await expect(downloadButton).toBeEnabled();
+    await expect(downloadButton).toHaveText('PDFをダウンロード');
+
+    // クリック → ダウンロード完了を並行で待つ
+    const downloadPromise = page.waitForEvent('download', { timeout: 60000 });
+    await downloadButton.click();
+
+    // クリック直後: 「準備中...」 に変わること
+    const preparingButton = page.getByRole('button', { name: '準備中...' });
+    await expect(preparingButton).toBeVisible({ timeout: 5000 });
+    await expect(preparingButton).toBeDisabled();
+
+    // ダウンロード完了を待つ
+    await downloadPromise;
+
+    // 完了後: 「PDFをダウンロード」に戻り有効になること
+    await expect(downloadButton).toBeEnabled({ timeout: 10000 });
+    await expect(downloadButton).toHaveText('PDFをダウンロード');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// blob URL の寿命: ダウンロード直後に URL が無効化されない
+// ---------------------------------------------------------------------------
+test.describe('blob URL のライフサイクル', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test('ダウンロード完了後もしばらく blob URL が有効である', async ({ page }) => {
+    await fillMinimalForm(page);
+
+    // revokeObjectURL の呼び出しを記録
+    await page.evaluate(() => {
+      (window as any).__revokeCalls = [] as { url: string; time: number }[];
+      const orig = URL.revokeObjectURL.bind(URL);
+      URL.revokeObjectURL = (url: string) => {
+        (window as any).__revokeCalls.push({ url, time: Date.now() });
+        orig(url);
+      };
+    });
+
+    const downloadButton = page.getByRole('button', { name: 'PDFをダウンロード' });
+    await downloadButton.scrollIntoViewIfNeeded();
+
+    const clickTime = Date.now();
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download', { timeout: 60000 }),
+      downloadButton.click(),
+    ]);
+
+    // ダウンロードが完了したこと
+    expect(download.suggestedFilename()).toMatch(/^invoice-.*\.pdf$/);
+
+    // ダウンロード完了直後: revokeObjectURL がまだ呼ばれていないこと
+    const revokeCalls = await page.evaluate(() => (window as any).__revokeCalls);
+    expect(revokeCalls).toHaveLength(0);
+  });
+});

--- a/e2e/full-flow.spec.ts
+++ b/e2e/full-flow.spec.ts
@@ -34,13 +34,9 @@ async function downloadPdfAndVerify(page: import('@playwright/test').Page) {
   await expect(downloadButton).toBeVisible({ timeout: 60000 });
   await expect(downloadButton).toBeEnabled({ timeout: 60000 });
 
-  // PDFDownloadLink の <a download href="blob:..."> が準備完了するのを待つ
-  const downloadLink = downloadButton.locator('xpath=ancestor::a');
-  await expect(downloadLink).toHaveAttribute('href', /.+/, { timeout: 60000 });
-
   const [download] = await Promise.all([
     page.waitForEvent('download', { timeout: 60000 }),
-    downloadLink.click(),
+    downloadButton.click(),
   ]);
 
   expect(download.suggestedFilename()).toMatch(/^invoice-.*\.pdf$/);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,65 +1,38 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { usePDF, PDFDownloadLink } from '@react-pdf/renderer';
+import React, { useState, useCallback } from 'react';
 import { InvoiceForm } from './components/InvoiceForm';
-import { InvoicePDF } from './components/InvoicePDF';
+import { InvoiceHTMLPreview } from './components/InvoiceHTMLPreview';
 import { InvoiceData } from './types';
-
-const DEBOUNCE_MS = 500;
 
 const DOWNLOAD_BTN_BASE =
   'inline-flex items-center justify-center border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50';
 
-function PdfPreview({ url, loading }: { url: string | null; loading: boolean }) {
-  return (
-    <div className="flex-1 border rounded-lg overflow-hidden relative">
-      {loading && (
-        <div className="absolute inset-0 bg-white/70 flex items-center justify-center z-10">
-          <p className="text-gray-500 text-sm">プレビュー更新中...</p>
-        </div>
-      )}
-      {url ? (
-        <iframe
-          src={url}
-          title="請求書プレビュー"
-          style={{ width: '100%', height: '100%', border: 'none' }}
-        />
-      ) : (
-        <div className="flex items-center justify-center h-full">
-          <p className="text-gray-400 text-sm">プレビューを生成中...</p>
-        </div>
-      )}
-    </div>
-  );
-}
-
 function App() {
-  const [invoiceData, setInvoiceData] = useState<InvoiceData | null>(null);
-  const [debouncedData, setDebouncedData] = useState<InvoiceData>(InvoiceForm.getInitialData());
-  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const [invoiceData, setInvoiceData] = useState<InvoiceData>(InvoiceForm.getInitialData());
+  const [downloading, setDownloading] = useState(false);
 
-  const latestData = invoiceData || InvoiceForm.getInitialData();
+  const latestData = invoiceData;
 
-  useEffect(() => {
-    if (!invoiceData) return;
-    clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => {
-      setDebouncedData(invoiceData);
-    }, DEBOUNCE_MS);
-    return () => clearTimeout(timerRef.current);
-  }, [invoiceData]);
-
-  // プレビュー用 PDF（デバウンスされたデータ）
-  const [previewInstance, updatePreview] = usePDF({
-    document: <InvoicePDF data={debouncedData} />,
-  });
-
-  useEffect(() => {
-    updatePreview(<InvoicePDF data={debouncedData} />);
-  }, [debouncedData, updatePreview]);
-
-  // ダウンロード: 単一の PDFDownloadLink（常に最新データ）
-  const pdfDocument = <InvoicePDF data={latestData} />;
-  const pdfFileName = `invoice-${latestData.invoiceNumber}.pdf`;
+  const handleDownload = useCallback(async () => {
+    setDownloading(true);
+    try {
+      // @react-pdf/renderer をダウンロード時のみ遅延ロード
+      const [{ pdf }, { InvoicePDF }] = await Promise.all([
+        import('@react-pdf/renderer'),
+        import('./components/InvoicePDF'),
+      ]);
+      const blob = await pdf(<InvoicePDF data={latestData} />).toBlob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `invoice-${latestData.invoiceNumber}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } finally {
+      setDownloading(false);
+    }
+  }, [latestData]);
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -67,19 +40,15 @@ function App() {
         <div className="flex flex-col xl:flex-row xl:space-x-8">
           <div className="xl:flex-1">
             <InvoiceForm onSubmit={setInvoiceData} />
-            {/* ダウンロードボタン（単一の PDFDownloadLink を1箇所のみマウント） */}
+            {/* ダウンロードボタン（クリック時にPDF生成） */}
             <div className="mt-6">
-              <PDFDownloadLink document={pdfDocument} fileName={pdfFileName}>
-                {/* @ts-ignore */}
-                {({ loading }) => (
-                  <button
-                    disabled={loading}
-                    className={`${DOWNLOAD_BTN_BASE} w-full px-4 py-3`}
-                  >
-                    {loading ? '準備中...' : 'PDFをダウンロード'}
-                  </button>
-                )}
-              </PDFDownloadLink>
+              <button
+                onClick={handleDownload}
+                disabled={downloading}
+                className={`${DOWNLOAD_BTN_BASE} w-full px-4 py-3`}
+              >
+                {downloading ? '準備中...' : 'PDFをダウンロード'}
+              </button>
             </div>
           </div>
 
@@ -88,7 +57,9 @@ function App() {
               <div className="flex items-center justify-between mb-6">
                 <h2 className="text-xl font-bold">プレビュー</h2>
               </div>
-              <PdfPreview url={previewInstance.url} loading={previewInstance.loading} />
+              <div className="flex-1 border rounded-lg overflow-hidden">
+                <InvoiceHTMLPreview data={latestData} />
+              </div>
             </div>
           </div>
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,12 @@ function App() {
 
   const handleDownload = useCallback(async () => {
     setDownloading(true);
+
+    // iOS Safari ではユーザージェスチャーが async 後に失効し a.click() が効かないため、
+    // ジェスチャーが有効な間に先にウィンドウを開いておく
+    const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+    const pdfWindow = isIOS ? window.open('about:blank', '_blank') : null;
+
     try {
       // @react-pdf/renderer をダウンロード時のみ遅延ロード
       const [{ pdf }, { InvoicePDF }] = await Promise.all([
@@ -22,13 +28,25 @@ function App() {
       ]);
       const blob = await pdf(<InvoicePDF data={latestData} />).toBlob();
       const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `invoice-${latestData.invoiceNumber}.pdf`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+
+      if (pdfWindow) {
+        // iOS: 事前に開いたウィンドウにPDFを表示（共有ボタンから保存可能）
+        pdfWindow.location.href = url;
+      } else {
+        // PC / Android: download 属性付きリンクでダウンロード
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `invoice-${latestData.invoiceNumber}.pdf`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+      }
+
+      // ダウンロード / 表示開始までの猶予を持たせてからURLを解放
+      setTimeout(() => URL.revokeObjectURL(url), 60_000);
+    } catch (e) {
+      pdfWindow?.close();
+      throw e;
     } finally {
       setDownloading(false);
     }

--- a/src/components/InvoiceForm.tsx
+++ b/src/components/InvoiceForm.tsx
@@ -3,7 +3,7 @@ import { format } from 'date-fns';
 import { FileText, Plus, Trash2, Eye, X } from 'lucide-react';
 import { InvoiceData, InvoiceItem } from '../types';
 import { calculateSubtotal, calculateTotals } from '../utils/calculations';
-import { InvoicePDF } from './InvoicePDF';
+import { InvoiceHTMLPreview } from './InvoiceHTMLPreview';
 import { Input } from './ui/input';
 import { Label } from './ui/label';
 import { Textarea } from './ui/textarea';
@@ -278,7 +278,7 @@ const InvoiceFormBase: React.FC<InvoiceFormProps> = ({ onSubmit, defaultValues }
               </button>
             </div>
             <div className="flex-1 overflow-hidden">
-              <InvoicePDF.Preview data={formData} className="w-full h-full" />
+              <InvoiceHTMLPreview data={formData} />
             </div>
           </div>
         </div>

--- a/src/components/InvoiceHTMLPreview.tsx
+++ b/src/components/InvoiceHTMLPreview.tsx
@@ -1,0 +1,241 @@
+import React from 'react';
+import { InvoiceData } from '../types';
+import { calculateSubtotal, calculateTotals } from '../utils/calculations';
+
+interface Props {
+  data: InvoiceData;
+}
+
+const PAGE_STYLE: React.CSSProperties = {
+  fontFamily: 'NotoSansJP, "Noto Sans JP", sans-serif',
+  padding: '50px',
+  fontSize: '10px',
+  lineHeight: 1.4,
+  color: '#000',
+  backgroundColor: '#fff',
+  width: '595px',
+  minHeight: '842px',
+  boxSizing: 'border-box',
+};
+
+export const InvoiceHTMLPreview: React.FC<Props> = ({ data }) => {
+  const totals = calculateTotals(data.items);
+
+  const itemsWithPadding = [...data.items];
+  if (itemsWithPadding.length < 5) {
+    const emptyRows = 5 - itemsWithPadding.length;
+    for (let i = 0; i < emptyRows; i++) {
+      itemsWithPadding.push({
+        description: '',
+        quantity: 0,
+        unitPrice: 0,
+        taxRate: 10,
+        notes: '',
+      });
+    }
+  }
+
+  const customerFirstLine = data.customerInfo.split('\n')[0];
+  const customerRest = data.customerInfo.split('\n').slice(1).join('\n');
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        overflow: 'auto',
+        display: 'flex',
+        justifyContent: 'center',
+        background: '#f3f4f6',
+        padding: '16px',
+      }}
+    >
+      <div
+        style={{
+          transformOrigin: 'top center',
+          flexShrink: 0,
+        }}
+      >
+        <div style={PAGE_STYLE}>
+          {/* Header */}
+          <div style={{ marginBottom: '20px' }}>
+            <div style={{ fontSize: '22px', textAlign: 'center', marginBottom: '10px' }}>
+              請求書
+            </div>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                marginBottom: '5px',
+                fontSize: '10px',
+              }}
+            >
+              <span>請求書番号: {data.invoiceNumber}</span>
+              <span>発行日: {data.issueDate}</span>
+            </div>
+          </div>
+
+          {/* Customer / Issuer info */}
+          <div style={{ display: 'flex', marginBottom: '20px' }}>
+            <div style={{ flex: 1, paddingRight: '10px' }}>
+              <div
+                style={{
+                  fontSize: '14px',
+                  fontWeight: 'bold',
+                  textDecoration: 'underline',
+                  marginBottom: '5px',
+                }}
+              >
+                {customerFirstLine}
+              </div>
+              <div style={{ fontSize: '10px', whiteSpace: 'pre-wrap' }}>{customerRest}</div>
+            </div>
+            <div style={{ flex: 1, paddingRight: '10px' }}>
+              <div style={{ fontSize: '10px', whiteSpace: 'pre-wrap' }}>{data.issuerInfo}</div>
+            </div>
+          </div>
+
+          {/* Subject */}
+          {data.subject ? (
+            <div style={{ fontWeight: 'bold', marginTop: '20px' }}>件名: {data.subject}</div>
+          ) : null}
+
+          {/* Total amount */}
+          <div style={{ fontSize: '10px', marginTop: '5px' }}>
+            下記のとおりご請求申し上げます。
+          </div>
+          <div
+            style={{
+              fontSize: '14px',
+              fontWeight: 'bold',
+              borderBottom: '1px solid #000',
+              paddingBottom: '2px',
+              marginTop: '10px',
+              marginBottom: '10px',
+              display: 'flex',
+              justifyContent: 'space-between',
+              width: '70%',
+            }}
+          >
+            <span>ご請求金額</span>
+            <span>¥ {totals.total.toLocaleString()} -</span>
+          </div>
+          <div style={{ fontSize: '10px', marginBottom: '20px' }}>
+            お支払い期限: {data.dueDate}
+          </div>
+
+          {/* Table */}
+          <div style={{ marginBottom: '20px' }}>
+            {/* Table header */}
+            <div
+              style={{
+                display: 'flex',
+                borderBottom: '1px solid #000',
+                paddingBottom: '5px',
+                marginBottom: '5px',
+              }}
+            >
+              <div style={{ width: '35%' }}>品目</div>
+              <div style={{ width: '15%', textAlign: 'right' }}>数量</div>
+              <div style={{ width: '17%', textAlign: 'right' }}>単価</div>
+              <div style={{ width: '15%', textAlign: 'right' }}>税率</div>
+              <div style={{ width: '18%', textAlign: 'right' }}>小計</div>
+            </div>
+
+            {/* Table rows */}
+            {itemsWithPadding.map((item, index) => (
+              <div
+                key={index}
+                style={{
+                  display: 'flex',
+                  paddingTop: '6px',
+                  paddingBottom: '6px',
+                  borderBottom: '1px solid #eee',
+                  minHeight: '25px',
+                  alignItems: 'flex-start',
+                }}
+              >
+                <div style={{ width: '35%' }}>
+                  <div>{item.description}</div>
+                  {item.notes ? (
+                    <div style={{ fontSize: '8px', color: '#666' }}>{item.notes}</div>
+                  ) : null}
+                </div>
+                <div style={{ width: '15%', textAlign: 'right' }}>
+                  {Number(item.quantity) || ''}
+                </div>
+                <div style={{ width: '17%', textAlign: 'right' }}>
+                  {Number(item.unitPrice)
+                    ? `¥${Number(item.unitPrice).toLocaleString()}`
+                    : ''}
+                </div>
+                <div style={{ width: '15%', textAlign: 'right' }}>
+                  {Number(item.quantity) ? `${Number(item.taxRate)}%` : ''}
+                </div>
+                <div style={{ width: '18%', textAlign: 'right' }}>
+                  {Number(item.quantity)
+                    ? `¥${calculateSubtotal(item).toLocaleString()}`
+                    : ''}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Totals */}
+          <div style={{ marginTop: '20px' }}>
+            {Object.entries(totals.subtotalsByTaxRate).map(([rate, subtotal]) => (
+              <div
+                key={rate}
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  marginBottom: '5px',
+                  fontSize: '10px',
+                }}
+              >
+                <span>小計:</span>
+                <span>¥{subtotal.toLocaleString()}</span>
+              </div>
+            ))}
+            {Object.entries(totals.taxesByRate).map(([rate, tax]) => (
+              <div
+                key={rate}
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  marginBottom: '5px',
+                  fontSize: '10px',
+                }}
+              >
+                <span>消費税（{rate}%）:</span>
+                <span>¥{tax.toLocaleString()}</span>
+              </div>
+            ))}
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                fontWeight: 'bold',
+              }}
+            >
+              <span>合計:</span>
+              <span>¥{totals.total.toLocaleString()}</span>
+            </div>
+          </div>
+
+          {/* Payment info */}
+          <div
+            style={{
+              marginTop: '50px',
+              paddingTop: '10px',
+              borderTop: '1px solid #000',
+            }}
+          >
+            <div style={{ fontWeight: 'bold' }}>お振込先:</div>
+            <div style={{ fontSize: '10px', whiteSpace: 'pre-wrap' }}>{data.paymentInfo}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/InvoicePDF.tsx
+++ b/src/components/InvoicePDF.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Document, Page, PDFViewer } from '@react-pdf/renderer';
+import { Document, Page } from '@react-pdf/renderer';
 import { InvoiceData } from '../types';
 import { InvoiceContent } from './InvoiceContent';
 
@@ -7,35 +7,7 @@ interface Props {
   data: InvoiceData;
 }
 
-interface PreviewProps extends Props {
-  className?: string;
-}
-
-const InvoicePDFPreview: React.FC<PreviewProps> = ({ data, className }) => {
-  return (
-    <PDFViewer 
-      className={className} 
-      showToolbar={false}
-      style={{
-        width: '100%',
-        height: '100%',
-        border: 'none',
-      }}
-    >
-      <Document>
-        <Page size="A4">
-          <InvoiceContent data={data} />
-        </Page>
-      </Document>
-    </PDFViewer>
-  );
-};
-
-type InvoicePDFComponent = React.FC<Props> & {
-  Preview: React.FC<PreviewProps>;
-};
-
-const InvoicePDF: InvoicePDFComponent = ({ data }) => {
+export const InvoicePDF: React.FC<Props> = ({ data }) => {
   return (
     <Document>
       <Page size="A4">
@@ -44,7 +16,3 @@ const InvoicePDF: InvoicePDFComponent = ({ data }) => {
     </Document>
   );
 };
-
-InvoicePDF.Preview = InvoicePDFPreview;
-
-export { InvoicePDF };

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,14 @@
 @tailwind components;
 @tailwind utilities;
 
+@font-face {
+  font-family: 'NotoSansJP';
+  src: url('/fonts/NotoSansJP-Regular.woff') format('woff');
+  font-weight: normal;
+  font-style: normal;
+  font-display: swap;
+}
+
 @layer base {
   :root {
     --background: 0 0% 100%;


### PR DESCRIPTION
## Summary

- **プレビューをPDF生成(iframe)からHTML/CSSレンダリングに変更** — 入力のたびにPDFブロブを生成する重い処理を排除し、Reactの通常の再レンダリングで即座にプレビュー表示
- **`@react-pdf/renderer`をダウンロード時のみ遅延ロード(dynamic import)** — 初期バンドルサイズ 1,559KB → 243KB（84%削減）
- **iOS Safari対応** — async後にユーザージェスチャーが失効する問題に対応。`window.open`で事前にタブを開きPDFを表示する方式
- **プラットフォーム別ダウンロード動作のE2Eテスト追加** — PC/iOS UA判定/ボタン状態/blob URL寿命を検証

## 変更の詳細

| Before | After |
|--------|-------|
| プレビュー: `usePDF` → PDFブロブ生成 → iframe | プレビュー: HTML/CSS で即座にレンダリング |
| ダウンロード: `PDFDownloadLink`（常時PDFインスタンス保持） | ダウンロード: クリック時のみ `pdf().toBlob()` |
| `@react-pdf/renderer` が初期バンドルに含まれる（1,314KB） | dynamic import で遅延ロード |
| iOS Safari: 未考慮 | `window.open` フォールバックで対応 |

## Test plan

- [x] 全66件のE2Eテスト通過（Desktop Chrome + Mobile Chrome）
- [x] PC: `window.open`が呼ばれず、downloadイベントで有効なPDFを取得できる
- [x] iOS: `window.open`が呼ばれ、blob URLが渡される
- [x] 非iOS UAでは`window.open`が呼ばれないことを検証
- [x] ダウンロード中に「準備中...」表示 + disabled → 完了後に復帰
- [x] `URL.revokeObjectURL`がダウンロード直後に呼ばれないことを検証
- [x] PDF内容検証（タイトル・明細・税計算・振込先等）が変更後も正しい

https://claude.ai/code/session_016mGcC11WBwQqebgHRwxEmk